### PR TITLE
Added required ASF links

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,11 +14,13 @@
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">Apache <b class="caret"></b></a>
             <ul class="dropdown-menu">
-              <li><a href="http://www.apache.org/" target="_blank">Apache Home</a></li>
-              <li><a href="http://www.apache.org/licenses/" target="_blank">Apache License v2.0</a></li>
-              <li><a href="http://www.apache.org/foundation/sponsorship.html" target="_blank">Donate</a></li>
-              <li><a href="http://www.apache.org/foundation/thanks.html" target="_blank">Thanks</a></li>
-              <li><a href="http://www.apache.org/security/" target="_blank">Security</a></li>
+              <li><a href="https://www.apache.org/" target="_blank">Apache Home</a></li>
+              <li><a href="https://www.apache.org/licenses/" target="_blank">License</a></li>
+              <li><a href="https://www.apache.org/foundation/sponsorship.html" target="_blank">Donate</a></li>
+              <li><a href="https://events.apache.org/" target="_blank">Events</a></li>
+              <li><a href="https://www.apache.org/foundation/thanks.html" target="_blank">Thanks</a></li>
+              <li><a href="https://www.apache.org/security/" target="_blank">Security</a></li>
+              <li><a href="https://privacy.apache.org/policies/privacy-policy-public.html" target="_blank">Privacy</a></li>
             </ul>
           </li>
         </ul>


### PR DESCRIPTION
As per [Apache Project Website Checks](https://whimsy.apache.org/site.cgi/project/thrift), we are missing:

* Events link — [Projects SHOULD include a link to any current CommunityOverCode event, or to the events.apache.org site, as provided by VP, Conferences.](https://www.apachecon.com/event-images/)
* License link is misspelled — [There should be a "License" (*not* "Licenses") navigation link which points to: http[s]://www.apache.org/licenses[/]. (Do not link to sub-pages)](https://www.apache.org/foundation/marks/pmcs#navigation)
* Privacy link — [All websites must link to the Privacy Policy.](https://www.apache.org/foundation/marks/pmcs.html#navigation)

<img width="592" height="604" alt="CleanShot 2026-04-18 at 10 02 06@2x" src="https://github.com/user-attachments/assets/42d47aed-a4a0-4d8b-a35e-fa4a2d1bb950" />

Switched links to `https://` as well