### PR TITLE
Added Thrift lexer to Rouge syntax highlighter

### DIFF
--- a/_plugins/thrift.rb
+++ b/_plugins/thrift.rb
@@ -1,0 +1,123 @@
+require 'rouge'
+require 'set'
+
+module Rouge
+  module Lexers
+    class Thrift < RegexLexer
+      desc 'Apache Thrift (https://thrift.apache.org/)'
+      tag 'thrift'
+      filenames '*.thrift'
+
+      mimetypes 'text/x-thrift', 'application/x-thrift'
+
+      def self.declarations
+        @declarations ||= Set.new %w(
+          include cpp_include namespace
+          const enum typedef struct union exception service
+          php_namespace xsd_namespace
+        )
+      end
+
+      def self.keywords
+        @keywords ||= Set.new %w(
+          smalltalk.category smalltalk.prefix
+
+          extends oneway throws
+          senum xsd_all
+        )
+      end
+
+      def self.keywords_type
+        @keywords_type ||= Set.new %w(
+          c_glib cocoa cpp csharp delphi go haxe java js lua
+          netstd perl php py py.twisted rb st xsd
+
+          required optional void
+          xsd_optional xsd_nillable xsd_attrs
+          python.immutable
+
+        )
+      end
+
+      def self.builtins
+        @builtins ||= Set.new %w(
+          bool byte i8 i16 i32 i64 double string binary uuid slist map set
+          list cpp_type
+        )
+      end
+
+      # Literal
+      # [37] Literal         ::=  ('"' [^"]* '"') | ("'" [^']* "'")
+      #
+      # Identifier
+      # [38] Identifier      ::=  ( Letter | '_' ) ( Letter | Digit | '.' | '_' )*
+      # [39] STIdentifier    ::=  ( Letter | '_' ) ( Letter | Digit | '.' | '_' | '-' )*
+      #
+      # List Separator
+      # [40] ListSeparator   ::=  ',' | ';'
+      #
+      # Letters and Digits
+      # [41] Letter          ::=  ['A'-'Z'] | ['a'-'z']
+      # [42] Digit           ::=  ['0'-'9']
+
+
+
+
+
+      # [32] ConstValue      ::=  IntConstant | DoubleConstant | Literal | Identifier | ConstList | ConstMap
+      #
+      # [33] IntConstant     ::=  ('+' | '-')? Digit+
+      #
+      # [34] DoubleConstant  ::=  ('+' | '-')? Digit* ('.' Digit+)? ( ('E' | 'e') IntConstant )?
+      #
+      # [35] ConstList       ::=  '[' (ConstValue ListSeparator?)* ']'
+      #
+      # [36] ConstMap        ::=  '{' (ConstValue ':' ConstValue ListSeparator?)* '}'
+      #
+      double = /[+-]?(?:(?:\d+\.\d+|\.\d+)(?:[eE][+-]?\d+)?|\d+[eE][+-]?\d+)/
+      name = /[a-z_][a-z0-9_.]*/i
+      st_identifier = /[a-z_][a-z0-9_.-]*/i
+
+      state :comment do
+        rule /[^*]+/, Comment
+        rule %r([*]/), Comment, :pop!
+        rule /[*]+/, Comment
+      end
+
+      state :comments_and_whitespace do
+        rule %r(/[*]), Comment, :comment
+        rule %r(//.*$), Comment
+        rule %r(#.*$), Comment
+        rule /\s+/, Text
+      end
+
+      state :root do
+        mixin :comments_and_whitespace
+
+        rule /(smalltalk\.(?:category|prefix))(\s+)(#{st_identifier})/ do
+          groups Keyword, Text, Name
+        end
+
+        rule name do |m|
+          if self.class.keywords.include?(m[0])
+            token Keyword
+          elsif self.class.keywords_type.include?(m[0])
+            token Keyword::Type
+          elsif self.class.declarations.include?(m[0])
+            token Keyword::Declaration
+          elsif self.class.builtins.include?(m[0])
+            token Name::Builtin
+          else
+            token Name
+          end
+        end
+
+        rule /[()\[\]{};:=,<>*]/, Punctuation
+        rule /'.*?'/, Str
+        rule /".*?"/, Str
+        rule double, Num::Float
+        rule /[+-]?\d+/, Num::Integer
+      end
+    end
+  end
+end

--- a/index.md
+++ b/index.md
@@ -77,7 +77,7 @@ title: Home
   </ul>
   <div class="tab-content">
     <div class="tab-pane active" id="1">
-      {% remote_snippet tutorial/tutorial.thrift text 123,150 %}
+      {% remote_snippet tutorial/tutorial.thrift thrift 123,150 %}
     </div>
     <div class="tab-pane" id="2">
       {% remote_snippet tutorial/py/PythonClient.py py 35,55 %}


### PR DESCRIPTION
With https://github.com/apache/thrift-website/pull/14, we got more snippets rendering with syntax highlighting. Unfortunately, the homepage does not highlight Thrift source itself, which is a bit emberassing. 

There is a pull request open against Rouge here https://github.com/rouge-ruby/rouge/pull/787, it got stuck for the last 10 years. I will see if they will accept a change from me, but in the meantime we can bundle it with the site as a Jekyll plugin.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>
<img width="1830" height="1164" alt="CleanShot 2026-04-18 at 10 31 13@2x" src="https://github.com/user-attachments/assets/9a1118a9-1c5f-41fb-bbba-2723be6f16bd" />
</td>
<td>
<img width="1834" height="1166" alt="CleanShot 2026-04-18 at 10 55 55@2x" src="https://github.com/user-attachments/assets/f47c91f9-4748-4230-bb42-11489fabf9b2" />
</td>
</tr>
</table>

I have updated the keywords list, double const parsing, and comment matcher to include `#`-style comments.