### PR TITLE
THRIFT-5908: Libraries page incorrectly uses Gemfile as control file for Ruby

### DIFF
--- a/_data/external_packages.yml
+++ b/_data/external_packages.yml
@@ -25,7 +25,7 @@
   - [ "Perl",        "CPAN",          "https://metacpan.org/release/Thrift",                                 "lib/perl/Makefile.PL",       "jking",                     "" ]
   - [ "PHP",         "Packagist",     "https://packagist.org/packages/apache/thrift",                        "composer.json",              "jfarrell, bufferoverflow, jking",  "" ]
   - [ "Python",      "pypi",          "https://pypi.python.org/pypi/thrift",                                 "lib/py/setup.py",            "jfarrell",                  "stale at 0.11.0 - see THRIFT-4687" ]
-  - [ "Ruby",        "Ruby Gem",      "https://rubygems.org/gems/thrift",                                    "lib/rb/Gemfile",             "jfarrell",                  "stale at 0.11.0 - see THRIFT-4707" ]
+  - [ "Ruby",        "RubyGems",      "https://rubygems.org/gems/thrift",                                    "lib/rb/thrift.gemspec",      "jfarrell",                  "" ]
   - [ "Rust",        "Cargo",         "https://crates.io/crates/thrift",                                     "lib/rs/cargo.toml",          "all thrift committers",     "" ]
   - [ "Smalltalk",   "",              "",                                                                    "",                           "",                          "no official ASF package available" ]
   - [ "Swift",       "",              "",                                                                    "",                           "",                          "no official ASF package available" ]

--- a/lib/c_glib.md
+++ b/lib/c_glib.md
@@ -1,5 +1,5 @@
 ---
-title: C GLib
+title: C GLib library
 islib: true
 ---
 

--- a/lib/cl.md
+++ b/lib/cl.md
@@ -1,5 +1,5 @@
 ---
-title: Common Lisp Library README
+title: Common Lisp library
 islib: true
 ---
 


### PR DESCRIPTION
Removed the "stale" remark and fixed the path to the package file.

<img width="1904" height="672" alt="CleanShot 2026-04-26 at 10 28 16@2x" src="https://github.com/user-attachments/assets/30fbbca8-fd4b-4769-847d-9ba53e1ae8ce" />
