### PR TITLE
Added Apache Thrift changelog page

### DIFF
--- a/_plugins/remote_snippets.rb
+++ b/_plugins/remote_snippets.rb
@@ -27,6 +27,12 @@ class RemoteSnippet < Liquid::Tag
     content = ""
     if @range == "all"
       URI.open(url) {|f| content = f.read }
+    elsif @range.start_with?("#")
+      header, count = @range.split(",", 2)
+      header = "#{header} "
+      count = Integer(count) + 1
+      found = 0
+      URI.open(url) {|f| content = f.each_line.take_while { |line| found += (line.start_with?(header) ? 1 : 0); found <= count }.join() }
     else
       rangenums = @range.split(",", 2)
       first = 0

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,5 @@
+---
+title: "Changelog"
+---
+
+{% remote_snippet CHANGES.md direct ##,3 %}

--- a/download.md
+++ b/download.md
@@ -5,6 +5,8 @@ title: "Download"
 ## Release
 The latest stable release of Thrift is {{ site.current_release }} (released on {{ site.current_release_date }}).
 
+See the [Apache Thrift changelog](/changelog) for release notes and development history.
+
 * [thrift-{{ site.current_release }}.tar.gz]({{ site.mirror_url }}/thrift/{{ site.current_release }}/thrift-{{ site.current_release }}.tar.gz) \[[PGP]({{ site.release_url }}/{{ site.current_release }}/thrift-{{ site.current_release }}.tar.gz.asc)\]
 \[[SHA256]({{ site.release_url }}/{{ site.current_release }}/thrift-{{ site.current_release }}.tar.gz.sha256)\]
 \[[SHA1]({{ site.release_url }}/{{ site.current_release }}/thrift-{{ site.current_release }}.tar.gz.sha1)\]

--- a/index.md
+++ b/index.md
@@ -58,6 +58,7 @@ title: Home
     </p>
     <p>
       <h4>[<a href="/download">Other Downloads</a>]</h4>
+      <h4>[<a href="/changelog">Changelog</a>]</h4>
     </p>
   </div>
 </div>


### PR DESCRIPTION
It is currently harder than necessary to find Thrift changelogs:

* [GitHub releases](https://github.com/apache/thrift/releases/tag/v0.23.0) links to http://thrift.apache.org/download
* http://thrift.apache.org/download links to binaries and checksums
* The actual changelog is in the repository in the [CHANGES.md](https://github.com/apache/thrift/blob/master/CHANGES.md) file

This pull request renders the 3 (randomly chosen number) latest releases from the changelog on a separate page. This is done by adding a new syntax to the `remote_snippet` tag: `####,N` where number of `#` represents the markdown header level to count and N is the number of such headers. In case of Thrift changelog, we use second level headers, so `##,3` will render 3 versions.

## Screenshots

<img width="1926" height="800" alt="CleanShot 2026-04-29 at 13 28 24@2x" src="https://github.com/user-attachments/assets/bfc0fe25-db42-4daa-a272-4843a3b44663" />

---

<img width="1936" height="664" alt="CleanShot 2026-04-29 at 13 29 18@2x" src="https://github.com/user-attachments/assets/09260246-341b-44c3-bd5f-773391a85459" />

---

<img width="1586" height="1486" alt="CleanShot 2026-04-29 at 13 29 50@2x" src="https://github.com/user-attachments/assets/83b8bdd4-e7e8-4d02-8691-c9b03758eb5c" />
